### PR TITLE
parable to parable-php

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -10,7 +10,8 @@ use PhpCsFixer\Finder;
  */
 $finder = Finder::create()
     ->in(__DIR__)
-    ->exclude('tmp');
+    ->exclude('tmp')
+    ->append(['convert', 'csv2qif', 'help', 'validate']);
 
 return Config::create()
     ->setFinder($finder)

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ dmvdbrugge@macbook:~/csv2qif$ ./help
  Help                  /_/
 
 Available commands:
-  convert      Converts given ING CSV to QIF
-  csv2qif      Shows a UI for convert/validate
+  convert      Converts given ING CSV to QIF.
+  csv2qif      Shows a UI for convert/validate.
   help         Shows all commands available.
-  validate     Validates given ruleset for use with convert
+  validate     Validates given ruleset for use with convert.
 ```
 
 ## Examples & Documentation

--- a/app/Command/Convert.php
+++ b/app/Command/Convert.php
@@ -3,7 +3,6 @@
 namespace Csv2Qif\Command;
 
 use Csv2Qif\Actors\Converter;
-use Csv2Qif\Event\Hook;
 use Parable\Console\Command;
 use Parable\Console\Parameter;
 
@@ -19,17 +18,17 @@ class Convert extends Command
 
     protected $description = 'Converts given ING CSV to QIF.';
 
-    /** @var Hook */
-    private $hook;
+    /** @var Converter */
+    private $converter;
 
-    public function __construct(Hook $hook)
+    public function __construct(Converter $converter)
     {
         $this->addArgument(self::ARG_CSV, Parameter::PARAMETER_REQUIRED);
         $this->addArgument(self::ARG_QIF);
         $this->addOption(self::OPT_RULESET, Parameter::OPTION_VALUE_REQUIRED);
         $this->addOption(self::OPT_DEBUG);
 
-        $this->hook = $hook;
+        $this->converter = $converter;
     }
 
     public function run(): void
@@ -41,7 +40,6 @@ class Convert extends Command
         $ruleSet    = $this->parameter->getOption(self::OPT_RULESET) ?? '';
         $debugLevel = (int) $this->parameter->getOption(self::OPT_DEBUG);
 
-        $converter = new Converter($this->hook, $this->output);
-        $converter->convert($csv, $qif, $ruleSet, $debugLevel);
+        $this->converter->convert($csv, $qif, $ruleSet, $debugLevel);
     }
 }

--- a/app/Command/Ui.php
+++ b/app/Command/Ui.php
@@ -4,6 +4,7 @@ namespace Csv2Qif\Command;
 
 use Csv2Qif\UiComponents\MainWindow;
 use Parable\Console\Command;
+use Parable\Di\Container;
 
 use function extension_loaded;
 use function UI\run;
@@ -13,6 +14,14 @@ class Ui extends Command
     protected $name = 'csv2qif';
 
     protected $description = 'Shows a UI for convert/validate.';
+
+    /** @var Container */
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
 
     public function run(): void
     {
@@ -26,7 +35,7 @@ class Ui extends Command
             exit(1);
         }
 
-        $window = new MainWindow();
+        $window = $this->container->get(MainWindow::class);
         $window->show();
 
         run();

--- a/app/Command/Validate.php
+++ b/app/Command/Validate.php
@@ -3,7 +3,6 @@
 namespace Csv2Qif\Command;
 
 use Csv2Qif\Actors\Validator;
-use Csv2Qif\Event\Hook;
 use Parable\Console\Command;
 use Parable\Console\Parameter;
 
@@ -16,15 +15,15 @@ class Validate extends Command
 
     protected $description = 'Validates given ruleset for use with convert.';
 
-    /** @var Hook */
-    private $hook;
+    /** @var Validator */
+    private $validator;
 
-    public function __construct(Hook $hook)
+    public function __construct(Validator $validator)
     {
         $this->addArgument(self::ARG_RULESET, Parameter::PARAMETER_REQUIRED);
         $this->addOption(self::OPT_VERBOSE);
 
-        $this->hook = $hook;
+        $this->validator = $validator;
     }
 
     public function run(): void
@@ -33,8 +32,7 @@ class Validate extends Command
         $ruleSet = $this->parameter->getArgument(self::ARG_RULESET);
         $verbose = (int) ($this->parameter->getOption(self::OPT_VERBOSE) ?? 0);
 
-        $validator  = new Validator($this->hook, $this->output);
-        $errorCount = $validator->validate($ruleSet, $verbose);
+        $errorCount = $this->validator->validate($ruleSet, $verbose);
 
         // Signal result to the outside world
         exit($errorCount);

--- a/app/Console/Output.php
+++ b/app/Console/Output.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Csv2Qif\Console;
+
+use Throwable;
+
+/**
+ * TODO: Remove this intermediate class when parable-php/console#2 is merged.
+ */
+class Output extends \Parable\Console\Output
+{
+    public function parseTags(string $line): string
+    {
+        $tags = $this->getTagsFromString($line);
+
+        foreach ($tags as $tag) {
+            try {
+                $code = $this->getCodeFor($tag);
+            } catch (Throwable $throwable) {
+                continue;
+            }
+
+            $line = str_replace("<{$tag}>", $code, $line);
+            $line = str_replace("</{$tag}>", $this->predefinedTags['default'], $line);
+        }
+
+        return $line . $this->predefinedTags['default'];
+    }
+}

--- a/app/Event/Hook.php
+++ b/app/Event/Hook.php
@@ -2,14 +2,16 @@
 
 namespace Csv2Qif\Event;
 
-class Hook extends \Parable\Event\Hook
+use Parable\Event\EventManager;
+
+class Hook extends EventManager
 {
     public function reset(?string $event = null): void
     {
         if ($event !== null) {
-            $this->hooks[$event] = [];
+            $this->listeners[$event] = [];
         } else {
-            $this->hooks = [];
+            $this->listeners = [];
         }
     }
 }

--- a/app/File/QifWriter.php
+++ b/app/File/QifWriter.php
@@ -26,6 +26,6 @@ class QifWriter extends File
 
     private function writeTransaction(QIF\Transaction $transaction): void
     {
-        fwrite($this->handle, (string) $transaction . PHP_EOL);
+        fwrite($this->handle, $transaction . PHP_EOL);
     }
 }

--- a/app/RuleSet/RuleSetMatcher.php
+++ b/app/RuleSet/RuleSetMatcher.php
@@ -6,7 +6,6 @@ use Csv2Qif\Event\Hook;
 use Csv2Qif\RuleSet\Description\DescriptionMatcher;
 use Csv2Qif\RuleSet\Rules\Rules\RuleAllOf;
 use Csv2Qif\Transactions\IngTransaction;
-use Parable\DI\Container;
 
 use function is_array;
 use function str_replace;
@@ -27,7 +26,7 @@ class RuleSetMatcher
 
     public function __construct(DescriptionMatcher $description, Hook $hook)
     {
-        $this->config      = Container::create(RuleSetConfig::class);
+        $this->config      = new RuleSetConfig();
         $this->description = $description;
         $this->hook        = $hook;
     }

--- a/app/RuleSet/RuleSetValidator.php
+++ b/app/RuleSet/RuleSetValidator.php
@@ -8,7 +8,6 @@ use Csv2Qif\RuleSet\Exceptions\RuleSetConfigException;
 use Csv2Qif\RuleSet\Rules\Rules\RuleAllOf;
 use Csv2Qif\Transactions\IngTransaction;
 use Generator;
-use Parable\DI\Container;
 
 use function is_array;
 use function is_string;
@@ -31,7 +30,7 @@ class RuleSetValidator
 
     public function __construct(DescriptionValidator $description, Hook $hook)
     {
-        $this->config      = Container::create(RuleSetConfig::class);
+        $this->config      = new RuleSetConfig();
         $this->description = $description;
         $this->hook        = $hook;
     }

--- a/app/RuleSet/Rules/RulesFactory.php
+++ b/app/RuleSet/Rules/RulesFactory.php
@@ -2,6 +2,7 @@
 
 namespace Csv2Qif\RuleSet\Rules;
 
+use BadMethodCallException;
 use Csv2Qif\RuleSet\Rules\Exceptions\RulesParserException;
 use Csv2Qif\RuleSet\Rules\Rules\Rule;
 use Csv2Qif\RuleSet\Rules\Rules\RuleHasProperty;
@@ -9,15 +10,27 @@ use Csv2Qif\RuleSet\Rules\Rules\RuleHasReason;
 use Csv2Qif\RuleSet\Rules\Rules\RuleHasRules;
 use Csv2Qif\RuleSet\Rules\Rules\RuleHasValue;
 use Csv2Qif\RuleSet\Rules\Rules\RuleNot;
-use Parable\DI\Container;
+use Parable\Di\Container;
 
 class RulesFactory
 {
+    /** @var Container */
+    private static $container;
+
+    public static function setContainer(Container $container): void
+    {
+        self::$container = $container;
+    }
+
     /**
      * @param array|string $ruleConfig
      */
     public static function create($ruleConfig): Rule
     {
+        if (!self::$container instanceof Container) {
+            throw new BadMethodCallException('RulesFactory not properly initiated, container missing.');
+        }
+
         try {
             $parsed = RulesParser::parse($ruleConfig);
         } catch (RulesParserException $e) {
@@ -25,7 +38,7 @@ class RulesFactory
         }
 
         /** @var Rule $rule */
-        $rule = Container::create($parsed->getClass());
+        $rule = self::$container->build($parsed->getClass());
         $rule->setOrigin($parsed->getOrigin());
 
         if ($rule instanceof RuleHasReason) {
@@ -47,7 +60,7 @@ class RulesFactory
         }
 
         if ($parsed->isNot()) {
-            $not = Container::create(RuleNot::class);
+            $not = self::$container->build(RuleNot::class);
             $not->setOrigin($parsed->getOrigin());
             $not->setRules($rule);
 

--- a/app/UiComponents/ConvertBox.php
+++ b/app/UiComponents/ConvertBox.php
@@ -8,7 +8,7 @@ use Csv2Qif\RuleSet\RuleSetConfig;
 use DynamicComponents\AdvancedControls\Combo;
 use DynamicComponents\AdvancedControls\Radio;
 use DynamicComponents\Controls\Button;
-use Parable\DI\Container;
+use Parable\Di\Container;
 use UI\Controls\Box;
 use UI\Controls\Grid;
 use UI\Controls\Group;
@@ -20,13 +20,19 @@ use function sort;
 
 class ConvertBox extends Box
 {
+    /** @var Container */
+    private $container;
+
     /** @var FileSelect */
     private $csv;
 
     /** @var Combo */
     private $debug;
 
-    /** @var Output */
+    /** @var Hook */
+    private $hook;
+
+    /** @var UiOutput */
     private $output;
 
     /** @var FileSelect */
@@ -38,11 +44,13 @@ class ConvertBox extends Box
     /** @var Window */
     private $window;
 
-    public function __construct(Window $window)
+    public function __construct(Container $container, Hook $hook, Window $window)
     {
         parent::__construct(Box::Horizontal);
 
-        $this->window = $window;
+        $this->container = $container;
+        $this->hook      = $hook;
+        $this->window    = $window;
 
         $this->setPadded(true);
         $this->append($this->getLeftBox());
@@ -51,11 +59,10 @@ class ConvertBox extends Box
 
     public function __invoke(): void
     {
-        $hook = Container::get(Hook::class);
-        $hook->reset();
+        $this->hook->reset();
         $this->output->cls();
 
-        $converter  = new Converter($hook, $this->output);
+        $converter  = new Converter($this->container, $this->hook, $this->output);
         $useCsv     = $this->csv->getFile();
         $useQif     = $this->qif->getFile();
         $useRuleset = $this->ruleset->getSelectedText();
@@ -81,7 +88,7 @@ class ConvertBox extends Box
         // - Output => Maybe move out of tab?
         $outputEntry = new MultilineEntry(MultilineEntry::NoWrap);
         $outputEntry->setReadOnly(true);
-        $this->output = new Output($outputEntry);
+        $this->output = new UiOutput($outputEntry);
 
         // - Convert button
         $convert     = new Button('Convert', $this);

--- a/app/UiComponents/MainWindow.php
+++ b/app/UiComponents/MainWindow.php
@@ -2,18 +2,24 @@
 
 namespace Csv2Qif\UiComponents;
 
+use Csv2Qif\Event\Hook;
+use Csv2Qif\RuleSet\RuleSetValidator;
+use Parable\Di\Container;
 use UI\Controls\Tab;
 use UI\Size;
 use UI\Window;
 
 class MainWindow extends Window
 {
-    public function __construct()
+    public function __construct(Container $container)
     {
         parent::__construct('csv2qif', new Size(800, 600));
 
-        $convert  = new ConvertBox($this);
-        $validate = new ValidateBox($this);
+        $hook             = $container->get(Hook::class);
+        $ruleSetValidator = $container->get(RuleSetValidator::class);
+
+        $convert  = new ConvertBox($container, $hook, $this);
+        $validate = new ValidateBox($hook, $ruleSetValidator, $this);
 
         $tab = new Tab();
         $tab->append(' Convert ', $convert);

--- a/app/UiComponents/UiOutput.php
+++ b/app/UiComponents/UiOutput.php
@@ -2,6 +2,7 @@
 
 namespace Csv2Qif\UiComponents;
 
+use Csv2Qif\Console\Output;
 use UI\Controls\MultilineEntry;
 
 use function str_repeat;
@@ -9,7 +10,7 @@ use function substr;
 
 use const PHP_EOL;
 
-class Output extends \Parable\Console\Output
+class UiOutput extends Output
 {
     /** @var MultilineEntry */
     private $output;
@@ -18,67 +19,42 @@ class Output extends \Parable\Console\Output
     {
         $this->output = $output;
 
-        foreach ($this->tags as $key => $val) {
-            $this->tags[$key] = '';
+        foreach ($this->predefinedTags as $key => $val) {
+            $this->predefinedTags[$key] = '';
         }
     }
 
-    /**
-     * @param string $string
-     *
-     * @return $this
-     */
-    public function write($string)
+    public function write(string $string): void
     {
         $string = $this->parseTags($string);
 
         $this->enableClearLine();
         $this->output->append($string);
-
-        return $this;
     }
 
-    /**
-     * @param int $count
-     *
-     * @return $this
-     */
-    public function newline($count = 1)
+    public function newline(int $count = 1): void
     {
         $this->disableClearLine();
         $this->output->append(str_repeat(PHP_EOL, $count));
-
-        return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function cursorReset()
+    public function cursorReset(): void
     {
         // Cursor reset means we will be writing over stuff anyway,
         // just remove the current line
-        return $this->clearLine();
+        $this->clearLine();
     }
 
-    /**
-     * @return $this
-     */
-    public function cls()
+    public function cls(): void
     {
         $this->disableClearLine();
         $this->output->setText('');
-
-        return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function clearLine()
+    public function clearLine(): void
     {
         if (!$this->isClearLineEnabled()) {
-            return $this;
+            return;
         }
 
         $lastLineBreak = strrpos($this->output->getText(), PHP_EOL);
@@ -90,7 +66,5 @@ class Output extends \Parable\Console\Output
         }
 
         $this->disableClearLine();
-
-        return $this;
     }
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,21 @@
+<?php
+
+use Csv2Qif\RuleSet\Rules\RulesFactory;
+use Parable\Console\App;
+use Parable\Di\Container;
+
+chdir(__DIR__);
+require_once 'vendor/autoload.php';
+
+$di = new Container();
+
+/*
+ * Bootstrap the Di Container into
+ * all factories here:
+ */
+RulesFactory::setContainer($di);
+
+$app = $di->get(App::class);
+$app->setOnlyUseDefaultCommand(true);
+
+return [$app, $di];

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,12 @@
   },
   "require": {
     "php": ">=7.1.0",
-    "devvoh/parable": "^1.2",
     "stephenharris/phpqif": "^0.1",
     "dmvdbrugge/dynamic-components": "^0.1",
-    "symfony/yaml": "^4.1"
+    "symfony/yaml": "^4.1",
+    "parable-php/di": "^0.1.3",
+    "parable-php/event": "^0.2.0",
+    "parable-php/console": "^0.1.1"
   },
   "suggest": {
     "ext-ui": "Needed if you want to use the GUI (the ui command)"

--- a/composer.lock
+++ b/composer.lock
@@ -4,59 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffe0864a6c6aaee856afb3d6495839fc",
+    "content-hash": "12e34ce24df410e35cd1397d4e86b359",
     "packages": [
-        {
-            "name": "devvoh/parable",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/devvoh/parable.git",
-                "reference": "502fac01a6865e03634f1b83250611fc5d425787"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/devvoh/parable/zipball/502fac01a6865e03634f1b83250611fc5d425787",
-                "reference": "502fac01a6865e03634f1b83250611fc5d425787",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7"
-            },
-            "bin": [
-                "parable"
-            ],
-            "type": "framework",
-            "autoload": {
-                "psr-4": {
-                    "Parable\\": "src/"
-                },
-                "files": [
-                    "src/defines.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Robin de Graaf",
-                    "email": "hello@devvoh.com",
-                    "homepage": "https://devvoh.com"
-                }
-            ],
-            "description": "Parable is a PHP micro framework",
-            "homepage": "https://devvoh.com/parable",
-            "keywords": [
-                "framework",
-                "micro"
-            ],
-            "time": "2018-06-10T19:17:08+00:00"
-        },
         {
             "name": "dmvdbrugge/dynamic-components",
             "version": "v0.1.0",
@@ -97,6 +46,152 @@
             ],
             "description": "Dynamic Components for the PHP UI extension",
             "time": "2018-09-17T19:27:21+00:00"
+        },
+        {
+            "name": "parable-php/console",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/parable-php/console.git",
+                "reference": "667be3cf2161f0c7fc6ae6688e2a117ba77a2340"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/parable-php/console/zipball/667be3cf2161f0c7fc6ae6688e2a117ba77a2340",
+                "reference": "667be3cf2161f0c7fc6ae6688e2a117ba77a2340",
+                "shasum": ""
+            },
+            "require": {
+                "parable-php/di": "^0.1.1",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Parable\\Console\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robin de Graaf",
+                    "email": "hello@devvoh.com",
+                    "homepage": "https://devvoh.com"
+                }
+            ],
+            "description": "Parable Console is a terminal application building library",
+            "homepage": "https://github.com/parable-php/console",
+            "keywords": [
+                "console",
+                "framework",
+                "library",
+                "parable",
+                "terminal"
+            ],
+            "time": "2018-12-14T13:55:12+00:00"
+        },
+        {
+            "name": "parable-php/di",
+            "version": "0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/parable-php/di.git",
+                "reference": "a8045ef327e224a89c227f5892233e0cbe91442a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/parable-php/di/zipball/a8045ef327e224a89c227f5892233e0cbe91442a",
+                "reference": "a8045ef327e224a89c227f5892233e0cbe91442a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Parable\\Di\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robin de Graaf",
+                    "email": "hello@devvoh.com",
+                    "homepage": "https://devvoh.com"
+                }
+            ],
+            "description": "Parable DI is a micro Dependency Injection Container",
+            "homepage": "https://github.com/parable-php/di",
+            "keywords": [
+                "container",
+                "dependency-injection",
+                "di",
+                "library",
+                "micro",
+                "parable"
+            ],
+            "time": "2018-08-13T18:18:42+00:00"
+        },
+        {
+            "name": "parable-php/event",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/parable-php/event.git",
+                "reference": "8733869e3b19a3c62dc60f0ccac490f4b5a598f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/parable-php/event/zipball/8733869e3b19a3c62dc60f0ccac490f4b5a598f9",
+                "reference": "8733869e3b19a3c62dc60f0ccac490f4b5a598f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Parable\\Event\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robin de Graaf",
+                    "email": "hello@devvoh.com",
+                    "homepage": "https://devvoh.com"
+                }
+            ],
+            "description": "Parable Events is a simple event system",
+            "homepage": "https://github.com/parable-php/event",
+            "keywords": [
+                "event",
+                "library",
+                "listener",
+                "observer",
+                "parable"
+            ],
+            "time": "2018-08-13T16:04:35+00:00"
         },
         {
             "name": "stephenharris/phpqif",
@@ -140,7 +235,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -198,16 +293,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.1.4",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "b832cc289608b6d305f62149df91529a2ab3c314"
+                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b832cc289608b6d305f62149df91529a2ab3c314",
-                "reference": "b832cc289608b6d305f62149df91529a2ab3c314",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/761fa560a937fd7686e5274ff89dcfa87a5047df",
+                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df",
                 "shasum": ""
             },
             "require": {
@@ -226,7 +321,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -253,7 +348,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-08-18T16:52:46+00:00"
+            "time": "2019-02-23T15:17:42+00:00"
         }
     ],
     "packages-dev": [
@@ -321,16 +416,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.3.0",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c"
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/b8e9745fb9b06ea6664d8872c4505fb16df4611c",
-                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/d17708133b6c276d6e42ef887a877866b909d892",
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892",
                 "shasum": ""
             },
             "require": {
@@ -361,7 +456,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-08-31T19:07:57+00:00"
+            "time": "2019-01-28T20:25:53+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -487,16 +582,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.13.0",
+            "version": "v2.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "7136aa4e0c5f912e8af82383775460d906168a10"
+                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/7136aa4e0c5f912e8af82383775460d906168a10",
-                "reference": "7136aa4e0c5f912e8af82383775460d906168a10",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ff401e58261ffc5934a58f795b3f95b355e276cb",
+                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb",
                 "shasum": ""
             },
             "require": {
@@ -505,9 +600,9 @@
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || >=7.0 <7.3",
+                "php": "^5.6 || ^7.0",
                 "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.2 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6",
                 "symfony/event-dispatcher": "^3.0 || ^4.0",
                 "symfony/filesystem": "^3.0 || ^4.0",
                 "symfony/finder": "^3.0 || ^4.0",
@@ -517,13 +612,10 @@
                 "symfony/process": "^3.0 || ^4.0",
                 "symfony/stopwatch": "^3.0 || ^4.0"
             },
-            "conflict": {
-                "hhvm": "*"
-            },
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.1",
+                "keradus/cli-executor": "^1.2",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.1",
                 "php-cs-fixer/accessible-object": "^1.0",
@@ -543,11 +635,6 @@
                 "php-cs-fixer"
             ],
             "type": "application",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.13-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -579,7 +666,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-08-23T13:15:44+00:00"
+            "time": "2019-02-17T17:44:13+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -679,16 +766,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -722,29 +809,33 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.1.4",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ca80b8ced97cf07390078b29773dc384c39eee1f"
+                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ca80b8ced97cf07390078b29773dc384c39eee1f",
-                "reference": "ca80b8ced97cf07390078b29773dc384c39eee1f",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9dc2299a016497f9ee620be94524e6c0af0280a9",
+                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
+                "symfony/contracts": "^1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
                 "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -755,7 +846,7 @@
                 "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
-                "psr/log-implementation": "For using the console logger",
+                "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -763,7 +854,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -790,24 +881,93 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:24:31+00:00"
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v4.1.4",
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "bfb30c2ad377615a463ebbc875eba64a99f6aa3e"
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/bfb30c2ad377615a463ebbc875eba64a99f6aa3e",
-                "reference": "bfb30c2ad377615a463ebbc875eba64a99f6aa3e",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v4.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "3354d2e6af986dd71f68b4e5cf4a933ab58697fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/3354d2e6af986dd71f68b4e5cf4a933ab58697fb",
+                "reference": "3354d2e6af986dd71f68b4e5cf4a933ab58697fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
@@ -826,7 +986,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -853,20 +1013,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T09:10:45+00:00"
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.1.4",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "c0f5f62db218fa72195b8b8700e4b9b9cf52eb5e"
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c0f5f62db218fa72195b8b8700e4b9b9cf52eb5e",
-                "reference": "c0f5f62db218fa72195b8b8700e4b9b9cf52eb5e",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e16b9e471703b2c60b95f14d31c1239f68f11601",
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601",
                 "shasum": ""
             },
             "require": {
@@ -876,7 +1036,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -903,20 +1063,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-08-18T16:52:46+00:00"
+            "time": "2019-02-07T11:40:08+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.1.4",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e162f1df3102d0b7472805a5a9d5db9fcf0a8068"
+                "reference": "267b7002c1b70ea80db0833c3afe05f0fbde580a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e162f1df3102d0b7472805a5a9d5db9fcf0a8068",
-                "reference": "e162f1df3102d0b7472805a5a9d5db9fcf0a8068",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/267b7002c1b70ea80db0833c3afe05f0fbde580a",
+                "reference": "267b7002c1b70ea80db0833c3afe05f0fbde580a",
                 "shasum": ""
             },
             "require": {
@@ -925,7 +1085,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -952,20 +1112,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:24:31+00:00"
+            "time": "2019-02-23T15:42:05+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.1.4",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "1913f1962477cdbb13df951f8147d5da1fe2412c"
+                "reference": "3896e5a7d06fd15fa4947694c8dcdd371ff147d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/1913f1962477cdbb13df951f8147d5da1fe2412c",
-                "reference": "1913f1962477cdbb13df951f8147d5da1fe2412c",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/3896e5a7d06fd15fa4947694c8dcdd371ff147d1",
+                "reference": "3896e5a7d06fd15fa4947694c8dcdd371ff147d1",
                 "shasum": ""
             },
             "require": {
@@ -974,7 +1134,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1006,20 +1166,20 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-07-26T08:55:25+00:00"
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
                 "shasum": ""
             },
             "require": {
@@ -1065,20 +1225,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "1e24b0c4a56d55aaf368763a06c6d1c7d3194934"
+                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/1e24b0c4a56d55aaf368763a06c6d1c7d3194934",
-                "reference": "1e24b0c4a56d55aaf368763a06c6d1c7d3194934",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/6b88000cdd431cd2e940caa2cb569201f3f84224",
+                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224",
                 "shasum": ""
             },
             "require": {
@@ -1124,20 +1284,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2018-09-21T06:26:08+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "95c50420b0baed23852452a7f0c7b527303ed5ae"
+                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/95c50420b0baed23852452a7f0c7b527303ed5ae",
-                "reference": "95c50420b0baed23852452a7f0c7b527303ed5ae",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
+                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
                 "shasum": ""
             },
             "require": {
@@ -1179,20 +1339,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v4.1.4",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "86cdb930a6a855b0ab35fb60c1504cb36184f843"
+                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/86cdb930a6a855b0ab35fb60c1504cb36184f843",
-                "reference": "86cdb930a6a855b0ab35fb60c1504cb36184f843",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
+                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
                 "shasum": ""
             },
             "require": {
@@ -1201,7 +1361,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1228,29 +1388,30 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-08-03T11:13:38+00:00"
+            "time": "2019-01-24T22:05:03+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.1.4",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "966c982df3cca41324253dc0c7ffe76b6076b705"
+                "reference": "b1a5f646d56a3290230dbc8edf2a0d62cda23f67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/966c982df3cca41324253dc0c7ffe76b6076b705",
-                "reference": "966c982df3cca41324253dc0c7ffe76b6076b705",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/b1a5f646d56a3290230dbc8edf2a0d62cda23f67",
+                "reference": "b1a5f646d56a3290230dbc8edf2a0d62cda23f67",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1277,7 +1438,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:00:49+00:00"
+            "time": "2019-01-16T20:31:39+00:00"
         }
     ],
     "aliases": [],

--- a/convert
+++ b/convert
@@ -3,13 +3,11 @@
 
 use Csv2Qif\Command\Convert;
 use Parable\Console\App;
-use Parable\DI\Container;
+use Parable\Di\Container;
 
-require_once __DIR__ . '/vendor/autoload.php';
+/** @var App $app */
+/** @var Container $di */
+[$app, $di] = require __DIR__ . '/bootstrap.php';
 
-$cmd = Container::get(Convert::class);
-
-Container::get(App::class)
-    ->setDefaultCommand($cmd)
-    ->setOnlyUseDefaultCommand(true)
-    ->run();
+$app->setDefaultCommand($di->get(Convert::class));
+$app->run();

--- a/csv2qif
+++ b/csv2qif
@@ -3,13 +3,11 @@
 
 use Csv2Qif\Command\Ui;
 use Parable\Console\App;
-use Parable\DI\Container;
+use Parable\Di\Container;
 
-require_once __DIR__ . '/vendor/autoload.php';
+/** @var App $app */
+/** @var Container $di */
+[$app, $di] = require __DIR__ . '/bootstrap.php';
 
-$cmd = Container::get(Ui::class);
-
-Container::get(App::class)
-    ->setDefaultCommand($cmd)
-    ->setOnlyUseDefaultCommand(true)
-    ->run();
+$app->setDefaultCommand($di->get(Ui::class));
+$app->run();

--- a/dynamicReturnTypeMeta.json
+++ b/dynamicReturnTypeMeta.json
@@ -1,18 +1,18 @@
 {
   "methodCalls": [
     {
-      "class": "\\Parable\\DI\\Container",
+      "class": "\\Parable\\Di\\Container",
       "method": "get",
       "position": 0
     },
     {
-      "class": "\\Parable\\DI\\Container",
-      "method": "create",
+      "class": "\\Parable\\Di\\Container",
+      "method": "build",
       "position": 0
     },
     {
-      "class": "\\Parable\\DI\\Container",
-      "method": "createAll",
+      "class": "\\Parable\\Di\\Container",
+      "method": "buildAll",
       "position": 0
     }
   ],

--- a/help
+++ b/help
@@ -6,12 +6,13 @@ use Csv2Qif\Command\Ui;
 use Csv2Qif\Command\Validate;
 use Parable\Console\App;
 use Parable\Console\Command\Help;
-use Parable\DI\Container;
+use Parable\Di\Container;
 
-require_once __DIR__ . '/vendor/autoload.php';
+/** @var App $app */
+/** @var Container $di */
+[$app, $di] = require __DIR__ . '/bootstrap.php';
 
-Container::get(App::class)
-    ->setName(<<<'NAME'
+$app->setName(<<<'NAME'
                   ___         _ ____
   ___________   _|__ \ ____ _(_) __/
  / ___/ ___/ | / /_/ // __ `/ / /_
@@ -19,13 +20,13 @@ Container::get(App::class)
 \___/____/ |___/____/\__, /_/_/
  Help                  /_/
 NAME
-    )
-    ->setOnlyUseDefaultCommand(true)
-    ->addCommands([
-        Container::get(Convert::class),
-        Container::get(Ui::class),
-        Container::get(Help::class),
-        Container::get(Validate::class),
-    ])
-    ->setDefaultCommandByName('help')
-    ->run();
+);
+$app->addCommands([
+    // Keep this list alphabetical by name
+    $di->get(Convert::class),
+    $di->get(Ui::class), // name is csv2qif
+    $di->get(Help::class),
+    $di->get(Validate::class),
+]);
+$app->setDefaultCommandByName('help');
+$app->run();

--- a/validate
+++ b/validate
@@ -3,13 +3,11 @@
 
 use Csv2Qif\Command\Validate;
 use Parable\Console\App;
-use Parable\DI\Container;
+use Parable\Di\Container;
 
-require_once __DIR__ . '/vendor/autoload.php';
+/** @var App $app */
+/** @var Container $di */
+[$app, $di] = require __DIR__ . '/bootstrap.php';
 
-$cmd = Container::get(Validate::class);
-
-Container::get(App::class)
-    ->setDefaultCommand($cmd)
-    ->setOnlyUseDefaultCommand(true)
-    ->run();
+$app->setDefaultCommand($di->get(Validate::class));
+$app->run();


### PR DESCRIPTION
Notable changes:
- Added bootstrap file doing the necessary repeated stuff.
- Added the command runners to php-cs-fixer configs.

Important parable changes:
- Required php version bumped from 5.6 to 7.1 so typehints are in.
- Parable\Console\App does no longer return $this on every setter.
- Parable\Console\Output now has predefinedTags instead of just tags.
- Said Output's writeln now only accepts a string, use writelns for array.
- Said Output currently has a blocking issue: throwing on unkown tags.
- Said blocking issue is temporarily fixed by intermediate class.
- Parable\DI became Parable\Di.
- Parable\Di\Container is not static. This hurt the most.
- Parable\Event\Hook has become Parable\Event\EventManager.
- Said EventManager has listen instead of into.

Closes #5 